### PR TITLE
Rename paths and references from 'success' to 'return'

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -11,7 +11,7 @@ module.exports = {
   bind: function (app) {
     var SERVICE_PATH = "/service/";
     var PAYMENT_PATH = "/proceed-to-payment";
-    var SUCCESS_PATH = "/success/";
+    var RETURN_PATH = "/return/";
     var PUBLIC_API_PAYMENTS_PATH = '/v1/payments/';
 
     function extractChargeId(frontEndRedirectionUrl) {
@@ -66,7 +66,7 @@ module.exports = {
     app.post(PAYMENT_PATH, function (req, res) {
       logger.info('POST ' + PAYMENT_PATH);
       var paymentReference = req.body.paymentReference;
-      var successPage = process.env.SERVICE_URL + SUCCESS_PATH + paymentReference;
+      var returnPage = process.env.SERVICE_URL + RETURN_PATH + paymentReference;
 
       var paymentData = {
         headers: {
@@ -76,7 +76,7 @@ module.exports = {
           'amount': parseInt(req.body.amount),
           'reference': req.body.reference,
           'description': req.body.description,
-          'return_url': successPage
+          'return_url': returnPage
         }
       };
 
@@ -117,7 +117,7 @@ module.exports = {
       });
     });
 
-    app.get(SUCCESS_PATH + ':paymentReference', function (req, res) {
+    app.get(RETURN_PATH + ':paymentReference', function (req, res) {
       var paymentReference = req.params.paymentReference;
       var chargeId = req.state[CHARGE_ID_PREFIX + paymentReference];
 

--- a/test/proceed_to_payment_ft_tests.js
+++ b/test/proceed_to_payment_ft_tests.js
@@ -49,7 +49,7 @@ portfinder.getPort(function (err, publicApiPort) {
             whenPublicApiReceivesPost({
                 'amount': 4000,
                 'description': description,
-                'return_url': localServerUrl + '/success/' + paymentReference
+                'return_url': localServerUrl + '/return/' + paymentReference
             }, '12345-67890-12345-67890').reply( 400, {
                 'message': 'Unknown gateway account: 11111'
             });
@@ -73,7 +73,7 @@ portfinder.getPort(function (err, publicApiPort) {
             whenPublicApiReceivesPost({
                 'amount': 4000,
                 'description': description,
-                'return_url': localServerUrl + '/success/' + paymentReference
+                'return_url': localServerUrl + '/return/' + paymentReference
             }, '12345-67890-12345-67890').reply(401, {
                 'message': 'Credentials are required to access this resource.'
             });
@@ -99,7 +99,7 @@ portfinder.getPort(function (err, publicApiPort) {
             whenPublicApiReceivesPost( {
                 'amount': 5000,
                 'description': description,
-                'return_url': localServerUrl + '/success/' + paymentReference
+                'return_url': localServerUrl + '/return/' + paymentReference
             },'12345-67890-12345-67890').reply( 201, {
                     'links': [ {
                         'href': frontendCardDetailsPath,

--- a/test/service_payment_confirmation_ft_tests.js
+++ b/test/service_payment_confirmation_ft_tests.js
@@ -18,21 +18,21 @@ portfinder.getPort(function (err, publicApiPort) {
     var publicApiGetPaymentsUrl = '/v1/payments/' + chargeId;
     var publicApiMock = nock(publicApiMockUrl);
 
-    var successPath = "/success/" + chargeReferenceId;
+    var completedPath = "/return/" + chargeReferenceId;
 
     function whenPublicApiReceivesGetPayment() {
         return publicApiMock.matchHeader('Accept', 'application/json')
                             .get(publicApiGetPaymentsUrl);
     }
 
-    function getSuccessPageResponse() {
+    function getReturnPageResponse() {
       var sessionData = {};
       sessionData['t_'+chargeReferenceId] = 'a-auth-token';
       sessionData['c_'+chargeReferenceId] = chargeId;
 
       var encryptedSession = clientSessions.util.encode(sessionConfig, sessionData);
 
-        return request(app).get(successPath)
+        return request(app).get(completedPath)
           .set('Cookie','state=' + encryptedSession)
           .set('Accept', 'application/json');
     }
@@ -60,7 +60,7 @@ portfinder.getPort(function (err, publicApiPort) {
                     }
                 );
 
-            getSuccessPageResponse()
+            getReturnPageResponse()
                 .expect(200, {
                     'title': 'Payment confirmation',
                     'confirmationMessage': 'Your payment has been successful',
@@ -82,7 +82,7 @@ portfinder.getPort(function (err, publicApiPort) {
                             { 'Content-Type': 'application/json' }
             );
 
-            getSuccessPageResponse()
+            getReturnPageResponse()
                 .expect(200, {
                     'message': 'Sorry, your payment has failed. Please contact us with following reference number.',
                     'paymentReference': chargeReferenceId + '-' + chargeId
@@ -111,7 +111,7 @@ portfinder.getPort(function (err, publicApiPort) {
                     }
                 );
 
-            getSuccessPageResponse()
+            getReturnPageResponse()
                 .expect(200, {
                   'message': 'Sorry, your payment has failed. Please contact us with following reference number.',
                   'paymentReference': chargeReferenceId + '-' + chargeId


### PR DESCRIPTION
The API defines a single URL for the platform to return the user to regardless of whether the payment succeeded or failed. There was a mismatch between the API and this app which was using 'success' as the name of the return page.

This PR changes the names of things in this app to be consistent with the API.