### PR TITLE
Use 'Pay API' in preference to 'Public API'

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ npm start
 
 | Name | Example | Description |
 | ---- | ------- | ----------- |
-| PUBLICAPI_URL | `https://api.pay.service.gov.uk/v1/` | URL of GOV.UK Pay API endpoint. |
+| PAY_API_URL | `https://api.pay.service.gov.uk/` | URL of GOV.UK Pay API endpoint. |
 | SERVICE_URL | `https://myapp.herokuapp.com/` | Publicly reachable URL of this service. Used to redirect back here after payment.. |

--- a/app/routes.js
+++ b/app/routes.js
@@ -12,7 +12,7 @@ module.exports = {
     var SERVICE_PATH = "/service/";
     var PAYMENT_PATH = "/proceed-to-payment";
     var RETURN_PATH = "/return/";
-    var PUBLIC_API_PAYMENTS_PATH = '/v1/payments/';
+    var PAY_API_PAYMENTS_PATH = '/v1/payments/';
 
     function extractChargeId(frontEndRedirectionUrl) {
       var chargeIdWithOneTimeToken = frontEndRedirectionUrl.split('/').pop();
@@ -84,13 +84,13 @@ module.exports = {
         paymentData.headers.Authorization = "Bearer " + req.state[AUTH_TOKEN_PREFIX + paymentReference];
       }
 
-      var publicApiUrl = process.env.PUBLICAPI_URL + PUBLIC_API_PAYMENTS_PATH;
+      var payApiUrl = process.env.PAY_API_URL + PAY_API_PAYMENTS_PATH;
       var errorMessage = 'Sample service failed to create charge';
-      client.post(publicApiUrl, paymentData, function (data, publicApiResponse) {
+      client.post(payApiUrl, paymentData, function (data, payApiResponse) {
 
-        logger.info('Publicapi response: ' + data);
+        logger.info('pay api response: ' + data);
 
-        if (publicApiResponse.statusCode == 201) {
+        if (payApiResponse.statusCode == 201) {
           var frontendCardDetailsUrl = findLinkForRelation(data.links, 'next_url');
           var chargeId = extractChargeId(frontendCardDetailsUrl.href);
 
@@ -101,7 +101,7 @@ module.exports = {
         }
 
         res.statusCode = 400;
-        if (publicApiResponse.statusCode == 401) {
+        if (payApiResponse.statusCode == 401) {
             errorMessage = 'Credentials are required to access this resource';
             res.statusCode = 401;
         }
@@ -110,7 +110,7 @@ module.exports = {
           'message': errorMessage
         });
       }).on('error', function (err) {
-        logger.error('Exception raised calling publicapi: ' + err);
+        logger.error('Exception raised calling pay api: ' + err);
         response(req, res, 'error', {
             'message': errorMessage
         });
@@ -121,14 +121,14 @@ module.exports = {
       var paymentReference = req.params.paymentReference;
       var chargeId = req.state[CHARGE_ID_PREFIX + paymentReference];
 
-      var publicApiUrl = process.env.PUBLICAPI_URL + PUBLIC_API_PAYMENTS_PATH + chargeId;
+      var payApiUrl = process.env.PAY_API_URL + PAY_API_PAYMENTS_PATH + chargeId;
       var args = {
         headers: {'Accept': 'application/json',
                   'Authorization': 'Bearer ' + req.state[AUTH_TOKEN_PREFIX + paymentReference] }
       };
 
-      client.get(publicApiUrl, args, function (data, publicApiResponse) {
-        if (publicApiResponse.statusCode == 200 && data.status === "SUCCEEDED") {
+      client.get(payApiUrl, args, function (data, payApiResponse) {
+        if (payApiResponse.statusCode == 200 && data.status === "SUCCEEDED") {
           var responseData = {
             'title': 'Payment confirmation',
             'confirmationMessage': 'Your payment has been successful',

--- a/test/paystart_ft_tests.js
+++ b/test/paystart_ft_tests.js
@@ -9,7 +9,7 @@ var cheerio = require('cheerio');
 var SERVICE_PATH = "/service/";
 var INVALID_AUTH_TOKEN_MSG = "Please enter a valid Authorization Token";
 
-portfinder.getPort(function (err, publicApiPort) {
+portfinder.getPort(function (err, payApiPort) {
 
     function getPaymentConfirmationWith(data) {
         return request(app).get(SERVICE_PATH + data);

--- a/test/proceed_to_payment_ft_tests.js
+++ b/test/proceed_to_payment_ft_tests.js
@@ -13,18 +13,18 @@ var sessionConfig = {
   'secret':     process.env.SESSION_ENCRYPTION_KEY
 };
 
-portfinder.getPort(function (err, publicApiPort) {
-    var publicApiMockUrl = 'http://localhost:' + publicApiPort;
+portfinder.getPort(function (err, payApiPort) {
+    var payApiMockUrl = 'http://localhost:' + payApiPort;
     var chargeId = '23144323';
     var paymentReference = '54321';
     var frontendCardDetailsPath = '/charge/' + chargeId;
-    var publicApiPaymentsUrl = '/v1/payments/';
-    var publicApiMock = nock(publicApiMockUrl);
+    var payApiPaymentsUrl = '/v1/payments/';
+    var payApiMock = nock(payApiMockUrl);
 
-    function whenPublicApiReceivesPost(data, token) {
-        return publicApiMock.matchHeader('Content-Type', 'application/json')
+    function whenPayApiReceivesPost(data, token) {
+        return payApiMock.matchHeader('Content-Type', 'application/json')
                             .matchHeader('Authorization', 'Bearer ' + token)
-                            .post(publicApiPaymentsUrl, data);
+                            .post(payApiPaymentsUrl, data);
     }
 
     function postProceedResponseWith(data, token) {
@@ -43,10 +43,10 @@ portfinder.getPort(function (err, publicApiPort) {
             var localServerUrl = 'http://this.server.url:3000';
             var description = 'payment description for failure';
 
-            process.env.PUBLICAPI_URL = publicApiMockUrl;
+            process.env.PAY_API_URL = payApiMockUrl;
             process.env.SERVICE_URL = localServerUrl;
 
-            whenPublicApiReceivesPost({
+            whenPayApiReceivesPost({
                 'amount': 4000,
                 'description': description,
                 'return_url': localServerUrl + '/return/' + paymentReference
@@ -67,10 +67,10 @@ portfinder.getPort(function (err, publicApiPort) {
             var localServerUrl = 'http://this.server.url:3000';
             var description = 'payment description for failure';
 
-            process.env.PUBLICAPI_URL = publicApiMockUrl;
+            process.env.PUBLICAPI_URL = payApiMockUrl;
             process.env.SERVICE_URL = localServerUrl;
 
-            whenPublicApiReceivesPost({
+            whenPayApiReceivesPost({
                 'amount': 4000,
                 'description': description,
                 'return_url': localServerUrl + '/return/' + paymentReference
@@ -93,10 +93,10 @@ portfinder.getPort(function (err, publicApiPort) {
             var localServerUrl = 'http://this.server.url:3000';
             var description = 'payment description for success';
 
-            process.env.PUBLICAPI_URL = publicApiMockUrl;
+            process.env.PAY_API_URL = payApiMockUrl;
             process.env.SERVICE_URL = localServerUrl;
 
-            whenPublicApiReceivesPost( {
+            whenPayApiReceivesPost( {
                 'amount': 5000,
                 'description': description,
                 'return_url': localServerUrl + '/return/' + paymentReference

--- a/test/service_payment_confirmation_ft_tests.js
+++ b/test/service_payment_confirmation_ft_tests.js
@@ -11,18 +11,18 @@ var sessionConfig = {
   'secret':     process.env.SESSION_ENCRYPTION_KEY
 };
 
-portfinder.getPort(function (err, publicApiPort) {
-    var publicApiMockUrl = 'http://localhost:' + publicApiPort;
+portfinder.getPort(function (err, payApiPort) {
+    var payApiMockUrl = 'http://localhost:' + payApiPort;
     var chargeReferenceId = 98765;
     var chargeId = '112233';
-    var publicApiGetPaymentsUrl = '/v1/payments/' + chargeId;
-    var publicApiMock = nock(publicApiMockUrl);
+    var payApiGetPaymentsUrl = '/v1/payments/' + chargeId;
+    var payApiMock = nock(payApiMockUrl);
 
     var completedPath = "/return/" + chargeReferenceId;
 
-    function whenPublicApiReceivesGetPayment() {
-        return publicApiMock.matchHeader('Accept', 'application/json')
-                            .get(publicApiGetPaymentsUrl);
+    function whenPayApiReceivesGetPayment() {
+        return payApiMock.matchHeader('Accept', 'application/json')
+                            .get(payApiGetPaymentsUrl);
     }
 
     function getReturnPageResponse() {
@@ -39,10 +39,10 @@ portfinder.getPort(function (err, publicApiPort) {
 
     describe('Payment workflow complete', function () {
         it('should show a success page when payment captured', function (done) {
-            process.env.PUBLICAPI_URL = publicApiMockUrl;
+            process.env.PAY_API_URL = payApiMockUrl;
             var amount = 3454;
 
-            whenPublicApiReceivesGetPayment()
+            whenPayApiReceivesGetPayment()
                 .reply(200, {
                     'payment_id': chargeId,
                     'amount': amount,
@@ -75,9 +75,9 @@ portfinder.getPort(function (err, publicApiPort) {
 
     describe('Payment workflow error', function () {
         it('should show an error page when payment-id invalid', function (done) {
-            process.env.PUBLICAPI_URL = publicApiMockUrl;
+            process.env.PAY_API_URL = payApiMockUrl;
 
-            whenPublicApiReceivesGetPayment()
+            whenPayApiReceivesGetPayment()
                 .reply(404, { 'message': 'some backend error' },
                             { 'Content-Type': 'application/json' }
             );
@@ -92,10 +92,10 @@ portfinder.getPort(function (err, publicApiPort) {
         });
 
         it('should show an error page when status not "SUCCEEDED"', function (done) {
-            process.env.PUBLICAPI_URL = publicApiMockUrl;
+            process.env.PAY_API_URL = payApiMockUrl;
             var amount = 3454;
 
-            whenPublicApiReceivesGetPayment()
+            whenPayApiReceivesGetPayment()
                 .reply(200, {
                     'payment_id': chargeId,
                     'amount': amount,


### PR DESCRIPTION
The code and README was littered to references to 'Public API'. Whilst this is meaningful to GOV.UK Pay developers, it isn't to external users. This commit replaces uses of 'Public API' with 'Pay API'.