### PR TITLE
Replace uses of chargeId with paymentId

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -87,9 +87,9 @@ module.exports = {
 
         if (payApiResponse.statusCode == 201) {
           var frontendCardDetailsUrl = findLinkForRelation(data.links, 'next_url');
-          var chargeId = data.paymentId;
+          var paymentId = data.paymentId;
 
-          req.state[CHARGE_ID_PREFIX + paymentReference] = chargeId;
+          req.state[CHARGE_ID_PREFIX + paymentReference] = paymentId;
           logger.info('Redirecting user to: ' + frontendCardDetailsUrl.href);
           res.redirect(303, frontendCardDetailsUrl.href);
           return;
@@ -114,9 +114,9 @@ module.exports = {
 
     app.get(RETURN_PATH + ':paymentReference', function (req, res) {
       var paymentReference = req.params.paymentReference;
-      var chargeId = req.state[CHARGE_ID_PREFIX + paymentReference];
+      var paymentId = req.state[CHARGE_ID_PREFIX + paymentReference];
 
-      var payApiUrl = process.env.PAY_API_URL + PAY_API_PAYMENTS_PATH + chargeId;
+      var payApiUrl = process.env.PAY_API_URL + PAY_API_PAYMENTS_PATH + paymentId;
       var args = {
         headers: {'Accept': 'application/json',
                   'Authorization': 'Bearer ' + req.state[AUTH_TOKEN_PREFIX + paymentReference] }
@@ -136,7 +136,7 @@ module.exports = {
         }
         response(req, res, 'error', {
           'message': 'Sorry, your payment has failed. Please contact us with following reference number.',
-          'paymentReference': paymentReference + '-' + chargeId
+          'paymentReference': paymentReference + '-' + paymentId
         });
       });
     });

--- a/app/routes.js
+++ b/app/routes.js
@@ -14,11 +14,6 @@ module.exports = {
     var RETURN_PATH = "/return/";
     var PAY_API_PAYMENTS_PATH = '/v1/payments/';
 
-    function extractChargeId(frontEndRedirectionUrl) {
-      var chargeIdWithOneTimeToken = frontEndRedirectionUrl.split('/').pop();
-      return chargeIdWithOneTimeToken.split('?')[0];
-    }
-
     app.get('/', function (req, res) {
       logger.info('GET /');
 
@@ -92,7 +87,7 @@ module.exports = {
 
         if (payApiResponse.statusCode == 201) {
           var frontendCardDetailsUrl = findLinkForRelation(data.links, 'next_url');
-          var chargeId = extractChargeId(frontendCardDetailsUrl.href);
+          var chargeId = data.paymentId;
 
           req.state[CHARGE_ID_PREFIX + paymentReference] = chargeId;
           logger.info('Redirecting user to: ' + frontendCardDetailsUrl.href);

--- a/test/proceed_to_payment_ft_tests.js
+++ b/test/proceed_to_payment_ft_tests.js
@@ -15,9 +15,9 @@ var sessionConfig = {
 
 portfinder.getPort(function (err, payApiPort) {
     var payApiMockUrl = 'http://localhost:' + payApiPort;
-    var chargeId = '23144323';
+    var paymentId = '23144323';
     var paymentReference = '54321';
-    var frontendCardDetailsPath = '/charge/' + chargeId;
+    var frontendCardDetailsPath = '/charge/' + paymentId;
     var payApiPaymentsUrl = '/v1/payments/';
     var payApiMock = nock(payApiMockUrl);
 

--- a/test/service_payment_confirmation_ft_tests.js
+++ b/test/service_payment_confirmation_ft_tests.js
@@ -14,8 +14,8 @@ var sessionConfig = {
 portfinder.getPort(function (err, payApiPort) {
     var payApiMockUrl = 'http://localhost:' + payApiPort;
     var chargeReferenceId = 98765;
-    var chargeId = '112233';
-    var payApiGetPaymentsUrl = '/v1/payments/' + chargeId;
+    var paymentId = '112233';
+    var payApiGetPaymentsUrl = '/v1/payments/' + paymentId;
     var payApiMock = nock(payApiMockUrl);
 
     var completedPath = "/return/" + chargeReferenceId;
@@ -28,7 +28,7 @@ portfinder.getPort(function (err, payApiPort) {
     function getReturnPageResponse() {
       var sessionData = {};
       sessionData['t_'+chargeReferenceId] = 'a-auth-token';
-      sessionData['c_'+chargeReferenceId] = chargeId;
+      sessionData['c_'+chargeReferenceId] = paymentId;
 
       var encryptedSession = clientSessions.util.encode(sessionConfig, sessionData);
 
@@ -44,7 +44,7 @@ portfinder.getPort(function (err, payApiPort) {
 
             whenPayApiReceivesGetPayment()
                 .reply(200, {
-                    'payment_id': chargeId,
+                    'payment_id': paymentId,
                     'amount': amount,
                     'reference': 'Test reference',
                     'description': 'Test description',
@@ -85,7 +85,7 @@ portfinder.getPort(function (err, payApiPort) {
             getReturnPageResponse()
                 .expect(200, {
                     'message': 'Sorry, your payment has failed. Please contact us with following reference number.',
-                    'paymentReference': chargeReferenceId + '-' + chargeId
+                    'paymentReference': chargeReferenceId + '-' + paymentId
                 })
                 .expect('Content-Type', 'application/json; charset=utf-8')
                 .end(done);
@@ -97,7 +97,7 @@ portfinder.getPort(function (err, payApiPort) {
 
             whenPayApiReceivesGetPayment()
                 .reply(200, {
-                    'payment_id': chargeId,
+                    'payment_id': paymentId,
                     'amount': amount,
                     'status': 'BLA_BLA',
                     'return_url': 'http://not.used.in/this/2324523',
@@ -114,7 +114,7 @@ portfinder.getPort(function (err, payApiPort) {
             getReturnPageResponse()
                 .expect(200, {
                   'message': 'Sorry, your payment has failed. Please contact us with following reference number.',
-                  'paymentReference': chargeReferenceId + '-' + chargeId
+                  'paymentReference': chargeReferenceId + '-' + paymentId
                 })
                 .expect('Content-Type', 'application/json; charset=utf-8')
                 .end(done);

--- a/test/service_payment_confirmation_ft_tests.js
+++ b/test/service_payment_confirmation_ft_tests.js
@@ -44,7 +44,7 @@ portfinder.getPort(function (err, payApiPort) {
 
             whenPayApiReceivesGetPayment()
                 .reply(200, {
-                    'payment_id': paymentId,
+                    'paymentId': paymentId,
                     'amount': amount,
                     'reference': 'Test reference',
                     'description': 'Test description',
@@ -97,7 +97,7 @@ portfinder.getPort(function (err, payApiPort) {
 
             whenPayApiReceivesGetPayment()
                 .reply(200, {
-                    'payment_id': paymentId,
+                    'paymentId': paymentId,
                     'amount': amount,
                     'status': 'BLA_BLA',
                     'return_url': 'http://not.used.in/this/2324523',


### PR DESCRIPTION
The Pay API uses the term paymentId, but the code was using about chargeId which won't mean anything to people outside the team.

This PR replaces uses of chargeId with paymentId to make the app easier to understand.