### PR TITLE
Fix processing of payment id from json responses

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -87,7 +87,7 @@ module.exports = {
 
         if (payApiResponse.statusCode == 201) {
           var frontendCardDetailsUrl = findLinkForRelation(data.links, 'next_url');
-          var paymentId = data.paymentId;
+          var paymentId = data.payment_id;
 
           req.state[CHARGE_ID_PREFIX + paymentReference] = paymentId;
           logger.info('Redirecting user to: ' + frontendCardDetailsUrl.href);

--- a/test/proceed_to_payment_ft_tests.js
+++ b/test/proceed_to_payment_ft_tests.js
@@ -105,7 +105,8 @@ portfinder.getPort(function (err, payApiPort) {
                         'href': frontendCardDetailsPath,
                         'rel': 'next_url',
                         'method': 'GET'
-                        } ]
+                      } ],
+                    'payment_id': "paymentId1234567890",
                     });
 
             postProceedResponseWith( {

--- a/test/service_payment_confirmation_ft_tests.js
+++ b/test/service_payment_confirmation_ft_tests.js
@@ -44,7 +44,7 @@ portfinder.getPort(function (err, payApiPort) {
 
             whenPayApiReceivesGetPayment()
                 .reply(200, {
-                    'paymentId': paymentId,
+                    'payment_id': paymentId,
                     'amount': amount,
                     'reference': 'Test reference',
                     'description': 'Test description',
@@ -97,7 +97,7 @@ portfinder.getPort(function (err, payApiPort) {
 
             whenPayApiReceivesGetPayment()
                 .reply(200, {
-                    'paymentId': paymentId,
+                    'payment_id': paymentId,
                     'amount': amount,
                     'status': 'BLA_BLA',
                     'return_url': 'http://not.used.in/this/2324523',


### PR DESCRIPTION
A previous commit changed the app to consistently use camel case for paymentId based on the docs in gelato. Turns out they were wrong. 