### PR TITLE
PP-611 Change amount to integer

### DIFF
--- a/app/controllers/pay_controller.js
+++ b/app/controllers/pay_controller.js
@@ -47,7 +47,7 @@ module.exports.bindRoutesTo = (app) => {
         'Authorization': 'Bearer ' + api.getKey(req)
       },
       data: {
-        'amount': req.body.amount,
+        'amount': parseInt(req.body.amount),
         'reference': req.body.reference,
         'description': req.body.description,
         'return_url': returnPage

--- a/test/pay_tests.js
+++ b/test/pay_tests.js
@@ -43,7 +43,7 @@ portfinder.getPort(function (err, payApiPort) {
               process.env.PAY_API_URL = payApiMockUrl;
 
               whenPayApiReceivesPost({
-                  'amount': '4000',
+                  'amount': 4000,
                   'description': description,
                   'reference': paymentReference,
                   'return_url': localServerUrl + '/return/' + paymentReference
@@ -52,7 +52,7 @@ portfinder.getPort(function (err, payApiPort) {
               });
 
               postProceedResponseWith(server, {
-                      'amount': '4000',
+                      'amount': 4000,
                       'description': description,
                       'reference': paymentReference
               }, '12345-67890-12345-67890').expect(400, {
@@ -68,7 +68,7 @@ portfinder.getPort(function (err, payApiPort) {
               process.env.PAY_API_URL = payApiMockUrl;
               
               whenPayApiReceivesPost({
-                  'amount': '4000',
+                  'amount': 4000,
                   'description': description,
                   'reference': paymentReference,
                   'return_url': localServerUrl + '/return/' + paymentReference
@@ -77,7 +77,7 @@ portfinder.getPort(function (err, payApiPort) {
               });
               
               postProceedResponseWith(server, {
-                      'amount': '4000',
+                      'amount': 4000,
                       'description': description,
                       'reference': paymentReference
               }, '12345-67890-12345-67890').expect(401, {
@@ -96,12 +96,12 @@ portfinder.getPort(function (err, payApiPort) {
                 process.env.PAY_API_URL = payApiMockUrl;
 
                 whenPayApiReceivesPost({
-                    'amount': '5000',
+                    'amount': 5000,
                     'description': description,
                     'reference': paymentReference,
                     'return_url': localServerUrl + '/return/' + paymentReference
                 }, '12345-67890-12345-67890').reply(201, {
-                    'amount': '5000',
+                    'amount': 5000,
                     'description': description,
                     'reference': paymentReference,
                     '_links': {
@@ -118,7 +118,7 @@ portfinder.getPort(function (err, payApiPort) {
 
                 postProceedResponseWith(server, {
                     'description': description,
-                    'amount': '5000',
+                    'amount': 5000,
                     'reference': paymentReference,
                     'integration': 'POST'
                 },'12345-67890-12345-67890')


### PR DESCRIPTION
    - PublicAPI strictly accept amount as an integer value
    and not string representations of an integer. Parse
    amount as an integer in pay request.