### PR TITLE
PP-541 Remove old states 'confirmed' and 'captured'.

### DIFF
--- a/app/controllers/return_controller.js
+++ b/app/controllers/return_controller.js
@@ -22,7 +22,7 @@ module.exports.bindRoutesTo = (app) => {
       };
     
       client.get(payApiUrl, paymentRequest, (data, payApiResponse) => {
-        if (payApiResponse.statusCode == 200 && (data.state.status === "confirmed" || data.state.status === "captured" || data.state.status === "success")) {
+        if ((payApiResponse.statusCode) == 200 && (data.state.status === "success")) {
           var responseData = {
             'title': 'Payment confirmation',
             'confirmationMessage': 'Your payment has been successful',

--- a/test/return_ft_tests.js
+++ b/test/return_ft_tests.js
@@ -37,7 +37,7 @@ portfinder.getPort(function (err, payApiPort) {
     }
 
     describe('Payment workflow complete', function () {
-        it('should show a success page when payment captured', function (done) {
+        it('should show a success page when payment successful', function (done) {
             process.env.PAY_API_URL = payApiMockUrl;
             var amount = 3454;
 
@@ -48,7 +48,7 @@ portfinder.getPort(function (err, payApiPort) {
                     'reference': 'Test reference',
                     'description': 'Test description',
                     'state': {
-                      'status' : 'confirmed',
+                      'status' : 'success',
                       'finished': true
                     },
                     'return_url': 'http://not.used.in/this/'+ chargeReferenceId,


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_
PP-541 Remove old states 'confirmed' and 'captured'.

## HOW 
_Steps to test or reproduce:_
States have been merged in to 'success'. We allowed this in a previous changeset, but can now remove the old states and with it backwards compatibility with the old code which has now been updated on all our environments.

## WHO
_Who should review this pull request:_

- [X] Developers
- [ ] WebOps



