### PR TITLE
PP-2329 Updated package.json with patched node.js engine version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "license": "MIT",
   "engines": {
-    "node": ">=5.6.0"
+    "node": "6.11.1"
   },
   "jshintConfig" : {
     "node": true,


### PR DESCRIPTION
## WHAT
Updates the node.js engine used by Heroku as specified in the package.json to the 6.11.1 version, which includes the July 2017 security update

## HOW 
Clone, ensure you are running node.js version 6.11.1 and run 'npm install' and then 'npm test' to ensure no issues with that new version.


