### PR TITLE
PP-8512: Archive notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # pay-sample-integration
+
+> As of September 2021 this repository is no longer actively maintained by the GOV.UK Pay team.
+
 Example service integration for GOV.UK Pay customer service.
 
 [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)


### PR DESCRIPTION
Adds archive notice, as part of our efforts to streamline Pay's Github repos.

This repository was for a Heroku demo app that showed an example of a service integrating with Pay. The demo itself was last updated in 2015, subsequent updates have been either dependency management or part of a cross-repo update of Pay's templating language from Mustache to Nunjucks (in 2017). If we wanted a similar demo app in the future it would probably need to be redone anyway, using modern GOV.UK prototype components etc.